### PR TITLE
Add dark mode theme via CSS variables

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,8 +9,13 @@
   --danger-color: #e74c3c;
   --dark-text: #2c3e50;
   --light-text: #ecf0f1;
+  --muted-text: #5f6368;
   --card-bg: #ffffff;
   --background: #f5f7fa;
+  --muted-bg: #f8f9fa;
+  --neutral-bg: #ecf0f1;
+  --input-border: #e8eaed;
+  --input-border-hover: #d2d5db;
   --border-radius: 10px;
   --box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   --transition: all 0.3s ease;
@@ -332,5 +337,25 @@ body {
   
   .app-header h1 {
     font-size: 1.75rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-color: #2980b9;
+    --primary-dark: #1c5e86;
+    --success-color: #27ae60;
+    --warning-color: #f39c12;
+    --danger-color: #c0392b;
+    --dark-text: #ecf0f1;
+    --light-text: #2c3e50;
+    --muted-text: #bdc3c7;
+    --card-bg: #2c3e50;
+    --background: #1a252f;
+    --muted-bg: #34495e;
+    --neutral-bg: #3d566e;
+    --input-border: #566573;
+    --input-border-hover: #808b96;
+    --box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
   }
 }

--- a/src/components/PeriodSelector.css
+++ b/src/components/PeriodSelector.css
@@ -1,10 +1,10 @@
 /* Period Selector Styles */
 
 .period-selector {
-    background-color: #fff;
-    border-radius: 10px;
+    background-color: var(--card-bg);
+    border-radius: var(--border-radius);
     padding: 16px 20px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--box-shadow);
     margin-bottom: 24px;
   }
   
@@ -24,7 +24,7 @@
   }
   
   .period-nav-btn {
-    background-color: #f5f7fa;
+    background-color: var(--muted-bg);
     border: none;
     border-radius: 8px;
     width: 36px;
@@ -37,7 +37,7 @@
   }
   
   .period-nav-btn:hover {
-    background-color: #e8eaed;
+    background-color: var(--input-border-hover);
   }
   
   .period-nav-btn:disabled {
@@ -46,7 +46,7 @@
   }
   
   .period-today-btn {
-    background-color: #3498db;
+    background-color: var(--primary-color);
     color: white;
     border: none;
     border-radius: 8px;
@@ -59,12 +59,12 @@
   }
   
   .period-today-btn:hover {
-    background-color: #2980b9;
+    background-color: var(--primary-dark);
   }
   
   .nav-icon {
     font-size: 1.1rem;
-    color: #5f6368;
+    color: var(--muted-text);
   }
   
   /* Select boxes */
@@ -82,7 +82,7 @@
   
   .select-container label {
     font-size: 0.8rem;
-    color: #5f6368;
+    color: var(--muted-text);
     font-weight: 500;
   }
   
@@ -93,24 +93,24 @@
   
   .custom-select select {
     appearance: none;
-    background-color: #f5f7fa;
-    border: 1px solid #e8eaed;
+    background-color: var(--muted-bg);
+    border: 1px solid var(--input-border);
     border-radius: 8px;
     padding: 8px 36px 8px 12px;
     font-size: 0.95rem;
-    color: #2c3e50;
+    color: var(--dark-text);
     cursor: pointer;
     width: 100%;
     transition: all 0.2s ease;
   }
   
   .custom-select select:hover {
-    border-color: #d2d5db;
-    background-color: #e8eaed;
+    border-color: var(--input-border-hover);
+    background-color: var(--input-border-hover);
   }
   
   .custom-select select:focus {
-    border-color: #3498db;
+    border-color: var(--primary-color);
     outline: none;
     box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2);
   }
@@ -122,7 +122,7 @@
     transform: translateY(-50%);
     pointer-events: none;
     font-size: 0.7rem;
-    color: #5f6368;
+    color: var(--muted-text);
   }
   
   .month-select {
@@ -138,7 +138,7 @@
     display: none;
     font-size: 1.1rem;
     font-weight: 500;
-    color: #2c3e50;
+    color: var(--dark-text);
     text-align: center;
     margin-top: 16px;
     text-transform: capitalize;

--- a/src/components/TransactionTable.css
+++ b/src/components/TransactionTable.css
@@ -9,10 +9,10 @@
   }
   
   .metric-card {
-    background-color: #fff;
-    border-radius: 10px;
+    background-color: var(--card-bg);
+    border-radius: var(--border-radius);
     padding: 20px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--box-shadow);
     position: relative;
     overflow: hidden;
     transition: all 0.3s ease;
@@ -26,7 +26,7 @@
   .metric-card h3 {
     font-size: 1rem;
     font-weight: 500;
-    color: #5f6368;
+    color: var(--muted-text);
     margin-bottom: 10px;
   }
   
@@ -37,27 +37,27 @@
   }
   
   .metric-card.income {
-    border-top: 4px solid #2ecc71;
+    border-top: 4px solid var(--success-color);
   }
-  
+
   .metric-card.expense {
-    border-top: 4px solid #e74c3c;
+    border-top: 4px solid var(--danger-color);
   }
-  
+
   .metric-card.savings {
-    border-top: 4px solid #3498db;
+    border-top: 4px solid var(--primary-color);
   }
   
   .metric-card.income .metric-value {
-    color: #2ecc71;
+    color: var(--success-color);
   }
-  
+
   .metric-card.expense .metric-value {
-    color: #e74c3c;
+    color: var(--danger-color);
   }
-  
+
   .metric-card.savings .metric-value {
-    color: #3498db;
+    color: var(--primary-color);
   }
   
   .metric-indicator {
@@ -68,40 +68,40 @@
   }
   
   .metric-indicator.positive {
-    color: #2ecc71;
+    color: var(--success-color);
   }
-  
+
   .metric-indicator.negative {
-    color: #e74c3c;
+    color: var(--danger-color);
   }
   
   .expense-ratio, .savings-rate {
     font-size: 0.9rem;
-    color: #5f6368;
+    color: var(--muted-text);
     opacity: 0.8;
   }
   
   .savings-progress {
     margin-top: 15px;
     height: 6px;
-    background-color: #ecf0f1;
+    background-color: var(--neutral-bg);
     border-radius: 3px;
     overflow: hidden;
   }
   
   .savings-progress-bar {
     height: 100%;
-    background-color: #3498db;
+    background-color: var(--primary-color);
     border-radius: 3px;
     transition: width 0.5s ease;
   }
   
   /* Transaction Table Styles */
   .transaction-container {
-    background-color: #fff;
-    border-radius: 10px;
+    background-color: var(--card-bg);
+    border-radius: var(--border-radius);
     padding: 20px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--box-shadow);
     margin-bottom: 30px;
   }
   
@@ -117,15 +117,15 @@
   .transaction-header h2 {
     font-size: 1.5rem;
     font-weight: 500;
-    color: #2c3e50;
+    color: var(--dark-text);
     margin: 0;
   }
   
   .transaction-count {
     font-size: 0.9rem;
-    color: #5f6368;
+    color: var(--muted-text);
     padding: 5px 12px;
-    background-color: #f8f9fa;
+    background-color: var(--muted-bg);
     border-radius: 16px;
   }
   
@@ -137,8 +137,8 @@
   .transaction-table th {
     text-align: left;
     padding: 12px 16px;
-    background-color: #f8f9fa;
-    color: #5f6368;
+    background-color: var(--muted-bg);
+    color: var(--muted-text);
     font-weight: 500;
     border-top: 1px solid rgba(0, 0, 0, 0.05);
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
@@ -166,11 +166,11 @@
   }
   
   .positive-value {
-    color: #2ecc71;
+    color: var(--success-color);
   }
-  
+
   .negative-value {
-    color: #e74c3c;
+    color: var(--danger-color);
   }
   
   /* Transaction row styles */
@@ -191,8 +191,8 @@
     position: absolute;
     top: 8px;
     right: 8px;
-    background-color: #3498db;
-    color: white;
+    background-color: var(--primary-color);
+    color: var(--light-text);
     font-size: 0.7rem;
     padding: 2px 6px;
     border-radius: 10px;
@@ -203,10 +203,10 @@
   .category-badge {
     display: inline-block;
     padding: 4px 10px;
-    background-color: #f8f9fa;
+    background-color: var(--muted-bg);
     border-radius: 16px;
     font-size: 0.85rem;
-    color: #5f6368;
+    color: var(--muted-text);
   }
   
   /* No data state */
@@ -216,9 +216,9 @@
     align-items: center;
     justify-content: center;
     padding: 40px 20px;
-    background-color: #fff;
-    border-radius: 10px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    background-color: var(--card-bg);
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
     text-align: center;
   }
   
@@ -241,7 +241,7 @@
     padding: 10px 0;
     font-size: 0.9rem;
     font-weight: 500;
-    color: #5f6368;
+    color: var(--muted-text);
     text-transform: capitalize;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
     margin-bottom: 10px;
@@ -256,11 +256,11 @@
   }
   
   .transaction-card.income-transaction {
-    border-left-color: #2ecc71;
+    border-left-color: var(--success-color);
   }
-  
+
   .transaction-card.expense-transaction {
-    border-left-color: #e74c3c;
+    border-left-color: var(--danger-color);
   }
   
   .transaction-main {
@@ -280,7 +280,7 @@
   
   .transaction-account {
     font-size: 0.85rem;
-    color: #5f6368;
+    color: var(--muted-text);
   }
   
   .transaction-amount {
@@ -299,7 +299,7 @@
   }
   
   .view-all-btn {
-    background-color: #3498db;
+    background-color: var(--primary-color);
     color: white;
     border: none;
     padding: 10px 24px;
@@ -308,9 +308,9 @@
     cursor: pointer;
     transition: all 0.2s ease;
   }
-  
+
   .view-all-btn:hover {
-    background-color: #2980b9;
+    background-color: var(--primary-dark);
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   }


### PR DESCRIPTION
## Summary
- provide root CSS variables for color and layout
- add dark mode theme using `prefers-color-scheme`
- refactor component styles to use the variables

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_683f5fb5e298832a909a3b8b53be1016